### PR TITLE
watchfiles 0.18.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "watchfiles" %}
 {% set version = "0.18.1" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -13,24 +12,22 @@ source:
 build:
   number: 0
   script:
-    - {{ PYTHON }} -m pip install . -vv
+    - {{ PYTHON }} -m pip install . -vv --no-deps
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
   entry_points:
     - watchfiles = watchfiles.cli:cli
 
-
 requirements:
   build:
-    - python
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
-    - cargo-bundle-licenses
-    - maturin
   host:
+    - cargo-bundle-licenses
     - maturin
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - python
     - anyio >=3.0.0,<4
@@ -47,8 +44,13 @@ test:
 about:
   home: https://watchfiles.helpmanual.io
   summary: Simple, modern and high performance file watching and code reload in python.
+  description: |
+    Watchfiles is a simple, modern and high performance file watching and code reload in python.
+    Underlying file system notifications are handled by the Notify rust library.
   dev_url: https://github.com/samuelcolvin/watchfiles
+  doc_url: https://watchfiles.helpmanual.io 
   license: MIT
+  license_family: MIT
   license_file:
     - LICENSE
     - THIRDPARTY.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,9 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
+    - cargo-bundle-licenses  # [win]
+    - maturin                # [win]
+    - python                 # [win]
   host:
     - cargo-bundle-licenses
     - maturin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  # maturin is missing on s390x
+  skip: true  # [s390x]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml


### PR DESCRIPTION
License: https://github.com/samuelcolvin/watchfiles/blob/v0.18.1/LICENSE
Changelog: https://github.com/samuelcolvin/watchfiles/releases
Requirements:
- https://github.com/samuelcolvin/watchfiles/blob/v0.18.1/Cargo.toml
- https://github.com/samuelcolvin/watchfiles/blob/v0.18.1/pyproject.toml
- https://github.com/samuelcolvin/watchfiles/blob/v0.18.1/setup.py

Actions:
1. Skip s390x
2. Add --no-deps
3. Move cargo-bundle-licenses and maturin from build to host
4. Add missing setuptools and wheel
5. Add description
6. Add license_family
7. Add doc_url