### PR TITLE
v0.24.0b1-rust-1.82

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: afb72325b74fa7a428c009c1b8be4b4d7c2afedafb2982827ef2156646df2fe1
 
 build:
-  number: 0
+  number: 1
   # maturin is missing on s390x.
   skip: true  # [s390x or py<=38]
   script:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6202](https://anaconda.atlassian.net/browse/PKG-6202)
 
### Explanation of changes:
  - Bump build number and build with rust 1.82

Rust < 1.81 was affected by CVE-2024-43402.

[PKG-6202]: https://anaconda.atlassian.net/browse/PKG-6202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ